### PR TITLE
[packages] Improve error messages for configuration path errors

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from esphome import git, yaml_util
 from esphome.components.substitutions import (
     ContextVars,
+    format_config_path,
     push_context,
     resolve_include,
     substitute,
@@ -38,83 +39,6 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = CONF_PACKAGES
 # Guard against infinite include chains (e.g. A includes B includes A).
 MAX_INCLUDE_DEPTH = 20
-
-
-def _path_doc(item: object) -> str | None:
-    """Return the source document name if *item* carries location info."""
-    if isinstance(item, yaml_util.ESPHomeDataBase):
-        r = item.esp_range
-        if r is not None:
-            return r.start_mark.document
-    return None
-
-
-def format_include_stack(path: list[str | int], current_obj: object) -> str:
-    """Build a human-readable include stack from a packages path.
-
-    Each YAML key in *path* that carries an ESPHomeDataBase ``esp_range``
-    reveals which file it came from.  When the source document changes between
-    consecutive such keys, that is an include boundary.  The path is split
-    into per-file frames and formatted innermost-first, e.g.::
-
-        In: packages->_roam_ in common/package/wifi.yaml 26:10
-          Included from packages->_wifi_ in common/sonoff_S26.yaml 44:2
-          Included from packages->device in Garland-Hall.yaml 11:2
-
-    The innermost ``In:`` line uses the location from *current_obj* when
-    available (the value that triggered the error) for extra precision.
-    """
-    # Split path into frames: start a new frame each time the source document
-    # changes among the path items that carry location info.
-    frames: list[tuple[list, str]] = []  # (path_segment, location_str)
-    current_doc: str | None = None
-    frame_start = 0
-    last_key_idx = -1
-    last_key_loc = ""
-
-    for i, item in enumerate(path):
-        doc = _path_doc(item)
-        if doc is None:
-            continue
-        loc = str(item.esp_range.start_mark)
-        if doc != current_doc:
-            if current_doc is not None:
-                frames.append(
-                    (list(path[frame_start : last_key_idx + 1]), last_key_loc)
-                )
-                frame_start = last_key_idx + 1
-            current_doc = doc
-        last_key_idx = i
-        last_key_loc = loc
-
-    if current_doc is not None:
-        frames.append((list(path[frame_start : last_key_idx + 1]), last_key_loc))
-
-    def fmt_path(seg: list) -> str:
-        return "->".join(str(s) for s in seg)
-
-    if not frames:
-        # No location info in path — use current_obj if possible
-        location = ""
-        if isinstance(current_obj, yaml_util.ESPHomeDataBase):
-            r = getattr(current_obj, "esp_range", None)
-            if r is not None:
-                location = f" in {r.start_mark}"
-        return f"In: {fmt_path(path)}{location}"
-
-    # For the innermost "In:" line prefer the current object's location
-    # (the value that triggered the error, usually more precise than the key).
-    inner_seg, inner_loc = frames[-1]
-    if isinstance(current_obj, yaml_util.ESPHomeDataBase):
-        r = getattr(current_obj, "esp_range", None)
-        if r is not None:
-            inner_loc = str(r.start_mark)
-
-    lines = [f"In: {fmt_path(inner_seg)} in {inner_loc}"]
-    for seg, loc in reversed(frames[:-1]):
-        lines.append(f"  Included from {fmt_path(seg)} in {loc}")
-
-    return "\n".join(lines)
 
 
 def is_remote_package(package_config: dict) -> bool:
@@ -458,7 +382,7 @@ def _substitute_package_definition(
                 strict_undefined=True,
             )
         except UndefinedError as err:
-            stack = format_include_stack(path, package_config)
+            stack = format_config_path(path, package_config)
             raise cv.Invalid(
                 f"Undefined variable in package definition: {err.message}.\n{stack}"
             ) from err

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -40,6 +40,83 @@ DOMAIN = CONF_PACKAGES
 MAX_INCLUDE_DEPTH = 20
 
 
+def _path_doc(item: object) -> str | None:
+    """Return the source document name if *item* carries location info."""
+    if isinstance(item, yaml_util.ESPHomeDataBase):
+        r = item.esp_range
+        if r is not None:
+            return r.start_mark.document
+    return None
+
+
+def format_include_stack(path: list[str | int], current_obj: object) -> str:
+    """Build a human-readable include stack from a packages path.
+
+    Each YAML key in *path* that carries an ESPHomeDataBase ``esp_range``
+    reveals which file it came from.  When the source document changes between
+    consecutive such keys, that is an include boundary.  The path is split
+    into per-file frames and formatted innermost-first, e.g.::
+
+        In: packages->_roam_ in common/package/wifi.yaml 26:10
+          Included from packages->_wifi_ in common/sonoff_S26.yaml 44:2
+          Included from packages->device in Garland-Hall.yaml 11:2
+
+    The innermost ``In:`` line uses the location from *current_obj* when
+    available (the value that triggered the error) for extra precision.
+    """
+    # Split path into frames: start a new frame each time the source document
+    # changes among the path items that carry location info.
+    frames: list[tuple[list, str]] = []  # (path_segment, location_str)
+    current_doc: str | None = None
+    frame_start = 0
+    last_key_idx = -1
+    last_key_loc = ""
+
+    for i, item in enumerate(path):
+        doc = _path_doc(item)
+        if doc is None:
+            continue
+        loc = str(item.esp_range.start_mark)
+        if doc != current_doc:
+            if current_doc is not None:
+                frames.append(
+                    (list(path[frame_start : last_key_idx + 1]), last_key_loc)
+                )
+                frame_start = last_key_idx + 1
+            current_doc = doc
+        last_key_idx = i
+        last_key_loc = loc
+
+    if current_doc is not None:
+        frames.append((list(path[frame_start : last_key_idx + 1]), last_key_loc))
+
+    def fmt_path(seg: list) -> str:
+        return "->".join(str(s) for s in seg)
+
+    if not frames:
+        # No location info in path — use current_obj if possible
+        location = ""
+        if isinstance(current_obj, yaml_util.ESPHomeDataBase):
+            r = getattr(current_obj, "esp_range", None)
+            if r is not None:
+                location = f" in {r.start_mark}"
+        return f"In: {fmt_path(path)}{location}"
+
+    # For the innermost "In:" line prefer the current object's location
+    # (the value that triggered the error, usually more precise than the key).
+    inner_seg, inner_loc = frames[-1]
+    if isinstance(current_obj, yaml_util.ESPHomeDataBase):
+        r = getattr(current_obj, "esp_range", None)
+        if r is not None:
+            inner_loc = str(r.start_mark)
+
+    lines = [f"In: {fmt_path(inner_seg)} in {inner_loc}"]
+    for seg, loc in reversed(frames[:-1]):
+        lines.append(f"  Included from {fmt_path(seg)} in {loc}")
+
+    return "\n".join(lines)
+
+
 def is_remote_package(package_config: dict) -> bool:
     """Returns True if the package_config is a remote package definition."""
     return CONF_URL in package_config
@@ -381,19 +458,9 @@ def _substitute_package_definition(
                 strict_undefined=True,
             )
         except UndefinedError as err:
-            location: str = ""
-            if (
-                isinstance(package_config, yaml_util.ESPHomeDataBase)
-                and package_config.esp_range is not None
-            ):
-                location: str = "->".join(str(x) for x in path)
-                if (
-                    isinstance(package_config, yaml_util.ESPHomeDataBase)
-                    and package_config.esp_range is not None
-                ):
-                    location += f" in {str(package_config.esp_range.start_mark)}"
+            stack = format_include_stack(path, package_config)
             raise cv.Invalid(
-                f"Undefined variable in package definition: {err.message} (see {location})"
+                f"Undefined variable in package definition: {err.message}.\n{stack}"
             ) from err
     return package_config
 

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -278,8 +278,9 @@ def _process_remote_package(config: dict, skip_update: bool = False) -> dict:
 
 def _walk_package_dict(
     packages: dict,
-    callback: Callable[[dict, ContextVars | None], dict],
+    callback: Callable[[dict, ContextVars | None, list], dict],
     context: ContextVars | None,
+    path: list[str | int],
 ) -> cv.Invalid | None:
     """Iterate a packages dict in reverse priority order, invoking callback on each entry.
 
@@ -288,7 +289,9 @@ def _walk_package_dict(
     for package_name, package_config in reversed(packages.items()):
         with cv.prepend_path(package_name):
             try:
-                packages[package_name] = callback(package_config, context)
+                packages[package_name] = callback(
+                    package_config, context, path + [package_name]
+                )
             except cv.Invalid as err:
                 return err
     return None
@@ -296,20 +299,22 @@ def _walk_package_dict(
 
 def _walk_package_list(
     packages: list,
-    callback: Callable[[dict, ContextVars | None], dict],
+    callback: Callable[[dict, ContextVars | None, list], dict],
     context: ContextVars | None,
+    path: list[str | int],
 ) -> None:
     """Iterate a packages list in reverse priority order, invoking callback on each entry."""
     for idx in reversed(range(len(packages))):
         with cv.prepend_path(idx):
-            packages[idx] = callback(packages[idx], context)
+            packages[idx] = callback(packages[idx], context, path + [idx])
 
 
 def _walk_packages(
     config: dict,
-    callback: Callable[[dict, ContextVars | None], dict],
+    callback: Callable[[dict, ContextVars | None, list], dict],
     context: ContextVars | None = None,
     validate_deprecated: bool = True,
+    path: list[str | int] | None = None,
 ) -> dict:
     """Walks the packages structure in priority order, invoking ``callback`` on each package definition found.
 
@@ -320,19 +325,24 @@ def _walk_packages(
     if CONF_PACKAGES not in config:
         return config
     packages = config[CONF_PACKAGES]
+    packages_path = (path or []) + [CONF_PACKAGES]
 
     with cv.prepend_path(CONF_PACKAGES):
         if isinstance(packages, yaml_util.IncludeFile):
             # If the packages key is an IncludeFile, resolve it first before processing.
-            packages, _ = resolve_include(packages, [], context, strict_undefined=False)
+            packages, _ = resolve_include(
+                packages, packages_path, context, strict_undefined=False
+            )
         if not isinstance(packages, (dict, list)):
             raise cv.Invalid(
                 f"Packages must be a key to value mapping or list, got {type(packages)} instead"
             )
 
         if not isinstance(packages, dict):
-            _walk_package_list(packages, callback, context)
-        elif (result := _walk_package_dict(packages, callback, context)) is not None:
+            _walk_package_list(packages, callback, context, packages_path)
+        elif (
+            result := _walk_package_dict(packages, callback, context, packages_path)
+        ) is not None:
             if not validate_deprecated or any(
                 is_package_definition(v) for v in packages.values()
             ):
@@ -341,14 +351,18 @@ def _walk_packages(
             # This block can be removed once the single-package
             # deprecation period (2026.7.0) is over.
             config[CONF_PACKAGES] = [packages]
-            return _walk_packages(deprecate_single_package(config), callback, context)
+            return _walk_packages(
+                deprecate_single_package(config), callback, context, path=path
+            )
 
     config[CONF_PACKAGES] = packages
     return config
 
 
 def _substitute_package_definition(
-    package_config: dict | str, context_vars: ContextVars | None
+    package_config: dict | str,
+    context_vars: ContextVars | None,
+    path: list[str | int],
 ) -> dict | str:
     """Substitute variables in a package definition string or remote package dict.
 
@@ -362,7 +376,7 @@ def _substitute_package_definition(
         try:
             package_config = substitute(
                 item=package_config,
-                path=[],
+                path=path,
                 parent_context=context_vars or ContextVars(),
                 strict_undefined=True,
             )
@@ -372,9 +386,14 @@ def _substitute_package_definition(
                 isinstance(package_config, yaml_util.ESPHomeDataBase)
                 and package_config.esp_range is not None
             ):
-                location = f" (in {str(package_config.esp_range.start_mark)})"
+                location: str = "->".join(str(x) for x in path)
+                if (
+                    isinstance(package_config, yaml_util.ESPHomeDataBase)
+                    and package_config.esp_range is not None
+                ):
+                    location += f" in {str(package_config.esp_range.start_mark)}"
             raise cv.Invalid(
-                f"Undefined variable in package definition: {err.message}{location}"
+                f"Undefined variable in package definition: {err.message} (see {location})"
             ) from err
     return package_config
 
@@ -433,6 +452,7 @@ class _PackageProcessor:
         self,
         package_config: dict | str | yaml_util.IncludeFile,
         context_vars: ContextVars | None,
+        path: list[str | int],
     ) -> dict:
         """Resolve a package definition to a concrete ``dict`` and fetch remote packages.
 
@@ -457,13 +477,13 @@ class _PackageProcessor:
             if isinstance(package_config, yaml_util.IncludeFile):
                 package_config, _ = resolve_include(
                     package_config,
-                    [],
+                    path,
                     context_vars or ContextVars(),
                     strict_undefined=False,
                 )
 
             package_config = _substitute_package_definition(
-                package_config, context_vars
+                package_config, context_vars, path
             )
             package_config = PACKAGE_SCHEMA(package_config)
             if isinstance(package_config, dict):
@@ -484,13 +504,16 @@ class _PackageProcessor:
             _update_substitutions_context(self.parent_context, subs)
 
     def process_package(
-        self, package_config: dict | str, context_vars: ContextVars | None
+        self,
+        package_config: dict | str,
+        context_vars: ContextVars | None,
+        path: list[str | int],
     ) -> dict:
         """Resolve a single package and recurse into any nested packages."""
         from_remote = isinstance(package_config, dict) and is_remote_package(
             package_config
         )
-        package_config = self.resolve_package(package_config, context_vars)
+        package_config = self.resolve_package(package_config, context_vars, path)
         self.collect_substitutions(package_config)
 
         if CONF_PACKAGES not in package_config:
@@ -510,6 +533,7 @@ class _PackageProcessor:
             self.process_package,
             context_vars,
             validate_deprecated=not from_remote,
+            path=path,
         )
 
 
@@ -561,11 +585,11 @@ def merge_packages(config: dict) -> dict:
     merge_list: list[dict] = []
 
     def process_package_callback(
-        package_config: dict, context: ContextVars | None
+        package_config: dict, context: ContextVars | None, path: list[str | int] = None
     ) -> dict:
         """This will be called for each package found in the config."""
         merge_list.append(package_config)
-        return _walk_packages(package_config, process_package_callback)
+        return _walk_packages(package_config, process_package_callback, path=path)
 
     _walk_packages(config, process_package_callback, validate_deprecated=False)
     # Merge all packages into the main config:

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -66,34 +66,24 @@ def format_config_path(path: SubstitutionPath, current_obj: object) -> str:
         loc = str(item.esp_range.start_mark)
         if doc != current_doc:
             if current_doc is not None:
-                frames.append(
-                    (list(path[frame_start : last_key_idx + 1]), last_key_loc)
-                )
-                frame_start = last_key_idx + 1
+                # Close the current frame.  Any integers immediately following
+                # the last located key are list indices belonging to that key
+                # (e.g. "packages[0]"), so consume them into this frame.
+                seg = list(path[frame_start : last_key_idx + 1])
+                j = last_key_idx + 1
+                while j < i and isinstance(path[j], int):
+                    seg.append(path[j])
+                    j += 1
+                frames.append((seg, last_key_loc))
+                frame_start = j  # next frame starts after the consumed integers
             current_doc = doc
         last_key_idx = i
         last_key_loc = loc
 
     if current_doc is not None:
-        frames.append((list(path[frame_start : last_key_idx + 1]), last_key_loc))
-
-    # Post-process: leading integers in a frame are list indices belonging to the
-    # previous frame's last key (e.g. path=[..., "packages", 0, "inner_pkg", ...]).
-    # Move them to the end of the previous frame so they format as "packages[0]".
-    processed: list[tuple[list, str]] = []
-    for seg, loc in frames:
-        leading: list[int] = []
-        rest = list(seg)
-        while rest and isinstance(rest[0], int):
-            leading.append(rest.pop(0))
-        if leading and processed:
-            prev_seg, prev_loc = processed[-1]
-            processed[-1] = (prev_seg + leading, prev_loc)
-        elif leading:
-            rest = leading + rest  # no previous frame — keep them at front
-        if rest:
-            processed.append((rest, loc))
-    frames = processed
+        seg = list(path[frame_start : last_key_idx + 1])
+        seg += [item for item in path[last_key_idx + 1 :] if isinstance(item, int)]
+        frames.append((seg, last_key_loc))
 
     def fmt_path(seg: list) -> str:
         """Format a path segment, rendering integers as [n] subscripts."""

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -44,8 +44,8 @@ def format_config_path(path: SubstitutionPath, current_obj: object) -> str:
     consecutive such keys, that is an include boundary.  The path is split
     into per-file frames and formatted innermost-first, e.g.::
 
-        In: packages->_roam_ in common/package/wifi.yaml 26:10
-          Included from packages->_wifi_ in common/hardware.yaml 44:2
+        In: packages->roam in common/package/wifi.yaml 26:10
+          Included from packages->net in common/hardware.yaml 44:2
           Included from packages->device in my_project.yaml 11:2
 
     The innermost ``In:`` line uses the location from *current_obj* when

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -25,6 +25,85 @@ _LOGGER = logging.getLogger(__name__)
 ContextVars = ChainMap[str, Any]
 SubstitutionPath = list[int | str]
 ErrList = list[tuple[UndefinedError, SubstitutionPath, Any]]
+
+
+def _path_doc(item: object) -> str | None:
+    """Return the source document name if *item* carries location info."""
+    if isinstance(item, ESPHomeDataBase):
+        r = item.esp_range
+        if r is not None:
+            return r.start_mark.document
+    return None
+
+
+def format_config_path(path: SubstitutionPath, current_obj: object) -> str:
+    """Build a human-readable include stack from a config path.
+
+    Each YAML key in *path* that carries an ``ESPHomeDataBase`` ``esp_range``
+    reveals which file it came from.  When the source document changes between
+    consecutive such keys, that is an include boundary.  The path is split
+    into per-file frames and formatted innermost-first, e.g.::
+
+        In: packages->_roam_ in common/package/wifi.yaml 26:10
+          Included from packages->_wifi_ in common/hardware.yaml 44:2
+          Included from packages->device in my_project.yaml 11:2
+
+    The innermost ``In:`` line uses the location from *current_obj* when
+    available (the value that triggered the error) for extra precision.
+    """
+    # Split path into frames: start a new frame each time the source document
+    # changes among the path items that carry location info.
+    frames: list[tuple[list, str]] = []  # (path_segment, location_str)
+    current_doc: str | None = None
+    frame_start = 0
+    last_key_idx = -1
+    last_key_loc = ""
+
+    for i, item in enumerate(path):
+        doc = _path_doc(item)
+        if doc is None:
+            continue
+        loc = str(item.esp_range.start_mark)
+        if doc != current_doc:
+            if current_doc is not None:
+                frames.append(
+                    (list(path[frame_start : last_key_idx + 1]), last_key_loc)
+                )
+                frame_start = last_key_idx + 1
+            current_doc = doc
+        last_key_idx = i
+        last_key_loc = loc
+
+    if current_doc is not None:
+        frames.append((list(path[frame_start : last_key_idx + 1]), last_key_loc))
+
+    def fmt_path(seg: list) -> str:
+        return "->".join(str(s) for s in seg)
+
+    if not frames:
+        # No location info in path — use current_obj if possible
+        location = ""
+        if isinstance(current_obj, ESPHomeDataBase):
+            r = getattr(current_obj, "esp_range", None)
+            if r is not None:
+                location = f" in {r.start_mark}"
+        return f"In: {fmt_path(path)}{location}"
+
+    # For the innermost "In:" line prefer the current object's location
+    # (the value that triggered the error, usually more precise than the key).
+    inner_seg, inner_loc = frames[-1]
+    if isinstance(current_obj, ESPHomeDataBase):
+        r = getattr(current_obj, "esp_range", None)
+        if r is not None:
+            inner_loc = str(r.start_mark)
+
+    lines = [f"In: {fmt_path(inner_seg)} in {inner_loc}"]
+    for seg, loc in reversed(frames[:-1]):
+        lines.append(f"  Included from {fmt_path(seg)} in {loc}")
+
+    return "\n".join(lines)
+
+
 # Module-level instance is safe: context_vars is passed per-call, and context_trace
 # is stack-saved/restored within expand(). Not thread-safe — only use from one thread.
 jinja = Jinja()
@@ -186,7 +265,7 @@ def _expand_substitutions(
                 f"\nEvaluation stack: (most recent evaluation last)"
                 f"\n{err.stack_trace_str()}"
                 f"\nRelevant context:\n{err.context_trace_str()}"
-                f"\nSee {'->'.join(str(x) for x in path)}",
+                f"\n{format_config_path(path, orig_value)}",
                 path,
             ) from err
         else:
@@ -401,16 +480,12 @@ def _warn_unresolved_variables(errors: ErrList) -> None:
     for err, path, expression in errors:
         if "password" in path:
             continue
-        location: str = "->".join(str(x) for x in path)
-        if isinstance(expression, ESPHomeDataBase) and expression.esp_range is not None:
-            location += f" in {str(expression.esp_range.start_mark)}"
-
         _LOGGER.warning(
             "The string '%s' looks like an expression,"
-            " but could not resolve all the variables: %s (see %s)",
+            " but could not resolve all the variables: %s\n%s",
             expression,
             err.message,
-            location,
+            format_config_path(path, expression),
         )
 
 

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -77,8 +77,36 @@ def format_config_path(path: SubstitutionPath, current_obj: object) -> str:
     if current_doc is not None:
         frames.append((list(path[frame_start : last_key_idx + 1]), last_key_loc))
 
+    # Post-process: leading integers in a frame are list indices belonging to the
+    # previous frame's last key (e.g. path=[..., "packages", 0, "inner_pkg", ...]).
+    # Move them to the end of the previous frame so they format as "packages[0]".
+    processed: list[tuple[list, str]] = []
+    for seg, loc in frames:
+        leading: list[int] = []
+        rest = list(seg)
+        while rest and isinstance(rest[0], int):
+            leading.append(rest.pop(0))
+        if leading and processed:
+            prev_seg, prev_loc = processed[-1]
+            processed[-1] = (prev_seg + leading, prev_loc)
+        elif leading:
+            rest = leading + rest  # no previous frame — keep them at front
+        if rest:
+            processed.append((rest, loc))
+    frames = processed
+
     def fmt_path(seg: list) -> str:
-        return "->".join(str(s) for s in seg)
+        """Format a path segment, rendering integers as [n] subscripts."""
+        parts: list[str] = []
+        for item in seg:
+            if isinstance(item, int):
+                if parts:
+                    parts[-1] = f"{parts[-1]}[{item}]"
+                else:
+                    parts.append(f"[{item}]")
+            else:
+                parts.append(str(item))
+        return "->".join(parts)
 
     if not frames:
         # No location info in path — use current_obj if possible
@@ -417,12 +445,8 @@ def _substitute_include(
     errors: ErrList | None,
 ) -> Any:
     """Resolve an include and substitute its content."""
-    content, filename = resolve_include(
-        include, path, context_vars, strict_undefined, errors
-    )
-    return substitute(
-        content, path + [f"<{filename}>"], context_vars, strict_undefined, errors
-    )
+    content, _ = resolve_include(include, path, context_vars, strict_undefined, errors)
+    return substitute(content, path, context_vars, strict_undefined, errors)
 
 
 def substitute(

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -8,12 +8,13 @@ import pytest
 
 from esphome.components.packages import (
     CONFIG_SCHEMA,
+    _substitute_package_definition,
     _walk_packages,
     do_packages_pass,
     is_package_definition,
     merge_packages,
 )
-from esphome.components.substitutions import do_substitution_pass
+from esphome.components.substitutions import ContextVars, do_substitution_pass
 import esphome.config as config_module
 from esphome.config import resolve_extend_remove
 from esphome.config_helpers import Extend, Remove
@@ -42,9 +43,9 @@ from esphome.const import (
     CONF_VARS,
     CONF_WIFI,
 )
-from esphome.core import CORE
+from esphome.core import CORE, DocumentLocation, DocumentRange
 from esphome.util import OrderedDict
-from esphome.yaml_util import IncludeFile, add_context
+from esphome.yaml_util import ESPHomeDataBase, IncludeFile, add_context, make_data_base
 
 # Test strings
 TEST_DEVICE_NAME = "test_device_name"
@@ -1405,3 +1406,52 @@ def test_raw_config_contains_merged_esphome_from_package(tmp_path) -> None:
         "CORE.raw_config should contain esphome section after package merge"
     )
     assert CORE.raw_config[CONF_ESPHOME][CONF_NAME] == TEST_DEVICE_NAME
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _located(value, doc: str, line: int, col: int):
+    """Return *value* wrapped with a fake ESPHomeDataBase source location."""
+    loc = DocumentLocation(doc, line, col)
+    obj = make_data_base(value)
+    if isinstance(obj, ESPHomeDataBase):
+        obj._esp_range = DocumentRange(loc, loc)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# _substitute_package_definition
+# ---------------------------------------------------------------------------
+
+
+class TestSubstitutePackageDefinition:
+    def test_local_dict_returned_unchanged(self):
+        """A plain local config dict is not substituted and is returned as-is."""
+        pkg = {CONF_WIFI: {CONF_SSID: "test"}}
+        result = _substitute_package_definition(pkg, ContextVars(), [])
+        assert result is pkg
+
+    def test_string_resolved_with_context(self):
+        """A string package definition has its variables substituted."""
+        ctx = ContextVars({"variant": "esp32"})
+        result = _substitute_package_definition("device-${variant}.yaml", ctx, [])
+        assert result == "device-esp32.yaml"
+
+    def test_undefined_variable_error_shows_include_chain(self):
+        """With a multi-level path the error lists each include boundary."""
+        path = [
+            "packages",
+            _located("device", "root.yaml", 10, 2),
+            "packages",
+            _located("inner", "hardware.yaml", 3, 2),
+        ]
+        with pytest.raises(cv.Invalid) as exc_info:
+            _substitute_package_definition("${undefined_var}", ContextVars(), path)
+        msg = str(exc_info.value)
+        assert "In:" in msg
+        assert "Included from" in msg
+        assert "root.yaml" in msg
+        assert "hardware.yaml" in msg

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1213,7 +1213,9 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
 
     call_count = 0
 
-    def failing_callback(package_config: dict, context: object) -> dict:
+    def failing_callback(
+        package_config: dict, context: object, path: list = None
+    ) -> dict:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -1249,7 +1251,9 @@ def test_validate_deprecated_false_raises_directly(
 
     call_count = 0
 
-    def failing_callback(package_config: dict, context: object) -> dict:
+    def failing_callback(
+        package_config: dict, context: object, path: list = None
+    ) -> dict:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -1281,7 +1285,7 @@ def test_error_on_first_declared_package_still_detected() -> None:
 
     call_count = 0
 
-    def fail_on_last(package_config: dict, context: object) -> dict:
+    def fail_on_last(package_config: dict, context: object, path: list = None) -> dict:
         nonlocal call_count
         call_count += 1
         # Reverse iteration: third_pkg (1), second_pkg (2), first_pkg (3)
@@ -1310,7 +1314,9 @@ def test_deprecated_single_package_fallback_still_works(
 
     attempt = 0
 
-    def fail_then_succeed(package_config: dict, context: object) -> dict:
+    def fail_then_succeed(
+        package_config: dict, context: object, path: list = None
+    ) -> dict:
         nonlocal attempt
         attempt += 1
         if attempt == 1:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -14,12 +14,14 @@ from esphome.components.packages import (
     do_packages_pass,
     merge_packages,
 )
+from esphome.components.substitutions import format_config_path
 from esphome.config import resolve_extend_remove
 from esphome.config_helpers import Extend, merge_config
 import esphome.config_validation as cv
 from esphome.const import CONF_SUBSTITUTIONS
-from esphome.core import CORE, EsphomeError, Lambda
+from esphome.core import CORE, DocumentLocation, DocumentRange, EsphomeError, Lambda
 from esphome.util import OrderedDict
+from esphome.yaml_util import ESPHomeDataBase, make_data_base
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -694,3 +696,89 @@ def test_resolve_package_undefined_var_in_include_filename(tmp_path: Path) -> No
     processor = _PackageProcessor({}, None, False)
     with pytest.raises(cv.Invalid, match="unresolved substitutions"):
         processor.resolve_package(package_config, substitutions.ContextVars(), [])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _located(value, doc: str, line: int, col: int):
+    """Return *value* wrapped with a fake ESPHomeDataBase source location."""
+    loc = DocumentLocation(doc, line, col)
+    obj = make_data_base(value)
+    if isinstance(obj, ESPHomeDataBase):
+        obj._esp_range = DocumentRange(loc, loc)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# format_config_path
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConfigPath:
+    def test_no_location_info_returns_flat_path(self):
+        """Plain path items with no esp_range produce a simple flat 'In:' line."""
+        result = format_config_path(["wifi", "ssid"], None)
+        assert result == "In: wifi->ssid"
+
+    def test_no_location_info_current_obj_adds_file(self):
+        """When path has no location but current_obj does, its location is shown."""
+        obj = _located("${var}", "main.yaml", 5, 10)
+        result = format_config_path(["wifi", "ssid"], obj)
+        assert result == "In: wifi->ssid in main.yaml 5:10"
+
+    def test_single_frame_no_include_boundary(self):
+        """All located keys from the same document → single 'In:' line, no 'Included from'."""
+        path = ["packages", _located("pkg1", "root.yaml", 5, 2)]
+        result = format_config_path(path, None)
+        assert result.startswith("In: packages->pkg1 in root.yaml 5:2")
+        assert "Included from" not in result
+
+    def test_two_frames_shows_included_from(self):
+        """Keys from two different documents produce 'In:' + one 'Included from' line."""
+        path = [
+            "packages",
+            _located("device", "root.yaml", 10, 2),
+            "packages",
+            _located("inner", "hardware.yaml", 3, 2),
+        ]
+        result = format_config_path(path, None)
+        assert "In: packages->inner in hardware.yaml 3:2" in result
+        assert "Included from packages->device in root.yaml 10:2" in result
+
+    def test_three_frames_full_include_stack(self):
+        """Three document levels produce two 'Included from' lines in correct order."""
+        path = [
+            "packages",
+            _located("device", "root.yaml", 10, 2),
+            "packages",
+            _located("_wifi_", "hardware.yaml", 43, 2),
+            "packages",
+            _located("_roam_", "wifi.yaml", 25, 2),
+        ]
+        result = format_config_path(path, None)
+        lines = result.splitlines()
+        assert lines[0].startswith("In: packages->_roam_ in wifi.yaml")
+        assert lines[1].startswith("  Included from packages->_wifi_ in hardware.yaml")
+        assert lines[2].startswith("  Included from packages->device in root.yaml")
+
+    def test_current_obj_overrides_innermost_location(self):
+        """current_obj's esp_range replaces the key's column for the 'In:' line."""
+        path = ["packages", _located("pkg1", "root.yaml", 5, 2)]
+        # Value (the expression) sits at column 10, not column 2 like the key
+        value = _located("${undefined}", "root.yaml", 5, 10)
+        result = format_config_path(path, value)
+        assert "5:10" in result
+        assert "5:2" not in result
+
+    def test_empty_path_with_no_location(self):
+        """Empty path with no location info returns 'In: '."""
+        result = format_config_path([], None)
+        assert result == "In: "
+
+    def test_integer_path_items_in_flat_fallback(self):
+        """Integer indices (list packages) appear in the flat 'In:' when no esp_range items exist."""
+        result = format_config_path(["packages", 0], None)
+        assert result == "In: packages->0"

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -778,7 +778,24 @@ class TestFormatConfigPath:
         result = format_config_path([], None)
         assert result == "In: "
 
-    def test_integer_path_items_in_flat_fallback(self):
-        """Integer indices (list packages) appear in the flat 'In:' when no esp_range items exist."""
+    def test_integer_path_items_formatted_as_subscript(self):
+        """Integer indices are rendered as [n] subscripts in the flat fallback."""
         result = format_config_path(["packages", 0], None)
-        assert result == "In: packages->0"
+        assert result == "In: packages[0]"
+
+    def test_integer_list_index_attached_to_previous_frame(self):
+        """A list index between two include boundaries attaches to the outer frame."""
+        path = [
+            "packages",
+            _located("packages", "main.yaml", 5, 0),
+            0,
+            _located("packages", "level1.yaml", 2, 0),
+            0,
+            _located("esphome", "level2.yaml", 0, 0),
+            _located("name", "level2.yaml", 1, 8),
+        ]
+        result = format_config_path(path, None)
+        lines = result.splitlines()
+        assert lines[0].startswith("In: esphome->name in level2.yaml")
+        assert "packages[0]" in lines[1] and "level1.yaml" in lines[1]
+        assert "packages[0]" in lines[2] and "main.yaml" in lines[2]

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -658,7 +658,7 @@ def test_resolve_package_max_depth_exceeded(tmp_path: Path) -> None:
         cv.Invalid,
         match=f"Maximum include nesting depth \\({MAX_INCLUDE_DEPTH}\\) exceeded",
     ):
-        processor.resolve_package(package_config, substitutions.ContextVars())
+        processor.resolve_package(package_config, substitutions.ContextVars(), [])
 
 
 def test_include_filename_substitution_undefined_var(tmp_path: Path) -> None:
@@ -693,4 +693,4 @@ def test_resolve_package_undefined_var_in_include_filename(tmp_path: Path) -> No
     )
     processor = _PackageProcessor({}, None, False)
     with pytest.raises(cv.Invalid, match="unresolved substitutions"):
-        processor.resolve_package(package_config, substitutions.ContextVars())
+        processor.resolve_package(package_config, substitutions.ContextVars(), [])


### PR DESCRIPTION
# What does this implement/fix?

Follow-up improvements to the error reporting introduced in the bugfix for esphome/esphome#15788 (`fix-15788` branch, submitted upstream as esphome/esphome#15844).

This series of commits significantly improves the quality of configuration error messages by:

- **Tracking the config path** through package/substitution resolution so errors report exactly where in the YAML tree the problem occurred (e.g. `packages.common.wifi.ssid`)
- **Including a stack dump** showing the chain of packages/substitutions that led to the error, making it easy to trace transitive errors across multiple files
- **Formatting list indices** in paths (e.g. `packages[0].wifi.ssid`) for clearer diagnosis
- **Refactoring `format_config_path`** into a shared utility in `substitutions/__init__.py`, reused by both the packages and substitutions components
- **Adding comprehensive tests** for path tracking and error message formatting

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- follow-up to esphome/esphome#15788
- continuation of esphome/esphome#15844

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:

```yaml
substitutions:
  board: esp32dev

packages:
  common: !include
    file: common.yaml
    vars:
      network: !include network/${network_type}.yaml  # path shown in error
```

**Error message example (before this PR):**
```
Invalid: 'network_type' is undefined
```

**Error message example (after this PR):**
```
Invalid: packages.common.vars.network: 'network_type' is undefined
  Included from config.yaml, line 7
  Included from common.yaml, line 3
```